### PR TITLE
Initializing TCPDF constants as instance parameters

### DIFF
--- a/extensions/helper/Pdf.php
+++ b/extensions/helper/Pdf.php
@@ -9,7 +9,7 @@ namespace li3_pdf\extensions\helper;
 
 use li3_pdf\extensions\PdfWrapper;
 
-class Pdf extends \lithium\template\Helper{
+class Pdf extends \lithium\template\Helper {
 	
 	protected $_classes = array(
 		'pdf' => 'li3_pdf\extensions\PdfWrapper'
@@ -20,9 +20,52 @@ class Pdf extends \lithium\template\Helper{
 	 */
 	private $_pdf = null;
 	
-	public function _init(){
+	/**
+	 * The page orientation based on TCPDF parameters
+	 */
+	public $orientation = 'P';
+	
+	/**
+	 * The page units based on TCPDF parameters
+	 */
+	public $unit = 'mm';
+	
+	/**
+	 * The page dimensions format based on TCPDF parameters
+	 */
+	public $format = 'LETTER';
+	
+	/**
+	 * Whether to render in Unicode
+	 */
+	public $unicode = true;
+	
+	/**
+	 * Encoding based on TCPDF parameters
+	 */
+	public $encoding = 'UTF-8';
+	
+	/**
+	 * Whether to reduce memory usage by caching temporary data on file system
+	 */
+	public $diskcache = false;
+	
+	/**
+	 * Sets PDF/A mode
+	 */
+	public $pdfa = false;
+	
+	public function _init() {
 		parent::_init();
-		$this->_pdf = new $this->_classes['pdf'](PDF_PAGE_ORIENTATION, PDF_UNIT, PDF_PAGE_FORMAT, true, 'UTF-8', false);
+		$this->_pdf = new $this->_classes['pdf'](
+			$this->orientation,
+			$this->unit,
+			$this->format,
+			$this->unicode,
+			$this->encoding,
+			$this->diskcache,
+			$this->pdfa
+		);
 	}
 	
 	public function __call($method, array $params = array()){


### PR DESCRIPTION
The TCPDF setPageFormat() method is protected, preventing customization of page dimensions without tweaking libraries. By replacing TCPDF constants with class properties, we can change values in the TCPDF constructor.
