### PR TITLE
Changed scope of _pdf to protected

### DIFF
--- a/extensions/helper/Pdf.php
+++ b/extensions/helper/Pdf.php
@@ -18,8 +18,8 @@ class Pdf extends \lithium\template\Helper {
 	/*
 	 * Holds the TCPDF instance
 	 */
-	private $_pdf = null;
 	
+	protected $_pdf = null;
 	/**
 	 * The page orientation based on TCPDF parameters
 	 */


### PR DESCRIPTION
Allows the helper to be extended without encountering errors.